### PR TITLE
Add user agent header to get_scores_soup

### DIFF
--- a/assets/soup.py
+++ b/assets/soup.py
@@ -4,6 +4,8 @@ from bs4 import BeautifulSoup
 # get scores soup per week
 def get_scores_soup(week, season_type):
   url = 'http://www.espn.com/nfl/schedule/_/week/' + week + '/seasontype/' + season_type
+  # ESPN requires a User-Agent header in the request
+  hdr = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36'}
   res = requests.get(url)
   res.raise_for_status()
   soup = BeautifulSoup(res.text, 'html.parser')

--- a/assets/soup.py
+++ b/assets/soup.py
@@ -6,7 +6,7 @@ def get_scores_soup(week, season_type):
   url = 'http://www.espn.com/nfl/schedule/_/week/' + week + '/seasontype/' + season_type
   # ESPN requires a User-Agent header in the request
   hdr = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36'}
-  res = requests.get(url, header=hdr)
+  res = requests.get(url, headers=hdr)
   res.raise_for_status()
   soup = BeautifulSoup(res.text, 'html.parser')
   return soup

--- a/assets/soup.py
+++ b/assets/soup.py
@@ -6,7 +6,7 @@ def get_scores_soup(week, season_type):
   url = 'http://www.espn.com/nfl/schedule/_/week/' + week + '/seasontype/' + season_type
   # ESPN requires a User-Agent header in the request
   hdr = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36'}
-  res = requests.get(url)
+  res = requests.get(url, header=hdr)
   res.raise_for_status()
   soup = BeautifulSoup(res.text, 'html.parser')
   return soup


### PR DESCRIPTION
I was seeing a 403 Forbidden response from the get request in soup.py. 

Adding a User-Agent string to the request seems to fix this issue